### PR TITLE
Potential fix for code scanning alert no. 5: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/test/utils/istio.go
+++ b/test/utils/istio.go
@@ -70,6 +70,12 @@ func extractTarEntry(tarReader *tar.Reader, header *tar.Header, tmpDir, absTmpDi
 	if err != nil {
 		return fmt.Errorf("failed to resolve path for %s: %w", header.Name, err)
 	}
+
+	safeBase := absTmpDir + string(os.PathSeparator)
+	if target != absTmpDir && !strings.HasPrefix(target, safeBase) {
+		return nil
+	}
+
 	rel, err := filepath.Rel(absTmpDir, target)
 	if err != nil {
 		return fmt.Errorf("failed to compute relative path for %s: %w", target, err)


### PR DESCRIPTION
Potential fix for [https://github.com/istio-ecosystem/fortsa/security/code-scanning/5](https://github.com/istio-ecosystem/fortsa/security/code-scanning/5)

To fix this cleanly, keep the existing logic but add an explicit, canonical “inside destination directory” validation directly after deriving the absolute target path, using a prefix check on a destination path normalized with a trailing separator. This pattern is easy for humans and static analyzers to reason about and addresses all three variants at once.

**Best single fix in `test/utils/istio.go` (within `extractTarEntry`)**:
1. Compute a normalized extraction root with trailing path separator:
   - `safeBase := absTmpDir + string(os.PathSeparator)`
2. Ensure `target` is either exactly `absTmpDir` or starts with `safeBase`; otherwise skip the entry.
3. Keep existing behavior for valid entries.

This does not change normal functionality (valid files still extract) but makes traversal prevention explicit and analyzer-friendly for all sinks (`MkdirAll`, `filepath.Dir`, `OpenFile`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
